### PR TITLE
Adding channel ID access

### DIFF
--- a/urbanairship.android.d.ts
+++ b/urbanairship.android.d.ts
@@ -10,5 +10,6 @@ export declare class NsUrbanairship implements CommonUrbanAirship {
     notificationOptOut(): Promise<boolean>;
     private setOptIn(optIn);
     isOptIn(): boolean;
+    getChannelID(): string;
     resetBadgeCount(): void;
 }

--- a/urbanairship.android.ts
+++ b/urbanairship.android.ts
@@ -60,6 +60,11 @@ export class NsUrbanairship implements CommonUrbanAirship {
 		return com.urbanairship.UAirship.shared().getPushManager().isPushEnabled();
 	}
 
+	public getChannelID(): string {
+		return com.urbanairship.UAirship.shared().getPushManager().getChannelId();
+	}
+
 	// support only for ios
 	public resetBadgeCount(): void { }
+	
 }

--- a/urbanairship.common.d.ts
+++ b/urbanairship.common.d.ts
@@ -7,11 +7,13 @@ export interface UrbanAirshipSettings {
     productionAppSecret: string;
     gcmSender?: string;
 }
+
 export interface CommonUrbanAirship {
     startUp(urbanAirshipSettings: UrbanAirshipSettings): void;
     registerUser(userId: string): void;
     notificationOptIn(): Promise<boolean>;
     isOptIn(): boolean;
+    getChannelID(): string;
     notificationOptOut(): Promise<boolean>;
     unRegisterUser(): void;
     resetBadgeCount(): void;

--- a/urbanairship.common.ts
+++ b/urbanairship.common.ts
@@ -13,6 +13,7 @@ export interface CommonUrbanAirship {
     registerUser(userId: string): void;
     notificationOptIn(): Promise<boolean>;
     isOptIn(): boolean;
+    getChannelID(): string;
     notificationOptOut(): Promise<boolean>;
     unRegisterUser(): void;
     resetBadgeCount(): void;

--- a/urbanairship.ios.d.ts
+++ b/urbanairship.ios.d.ts
@@ -10,5 +10,6 @@ export declare class NsUrbanairship implements CommonUrbanAirship {
     notificationOptOut(): Promise<boolean>;
     private setOptIn(optIn);
     isOptIn(): boolean;
+    getChannelID(): string;
     resetBadgeCount(): void;
 }

--- a/urbanairship.ios.ts
+++ b/urbanairship.ios.ts
@@ -59,6 +59,10 @@ export class NsUrbanairship implements CommonUrbanAirship {
 		return UAirship.push().userPushNotificationsEnabled;
 	}
 
+	public getChannelID(): string {
+		return UAirship.push().channelID;
+	}
+
 	public resetBadgeCount(): void {
 		UAirship.push().resetBadge();
 	}


### PR DESCRIPTION
Please note this is my first pull request.

Added the getChannelID method on android and ios to retrieve channelID and send it to remote server for serverside channel naming with urbanship API.